### PR TITLE
Add speed and channel fields to Edge dataclass

### DIFF
--- a/src/unifi_network_maps/model/topology.py
+++ b/src/unifi_network_maps/model/topology.py
@@ -37,6 +37,8 @@ class Edge:
     label: str | None = None
     poe: bool = False
     wireless: bool = False
+    speed: int | None = None
+    channel: int | None = None
 
 
 type DeviceSource = object
@@ -64,6 +66,7 @@ class PortInfo:
 
 type PortMap = dict[tuple[str, str], str]
 type PoeMap = dict[tuple[str, str], bool]
+type SpeedMap = dict[tuple[str, str], int]
 type ClientPortMap = dict[str, list[tuple[int, str]]]
 
 
@@ -421,7 +424,15 @@ def _tree_edges_from_parent(
             tree_edges.append(Edge(left=parent_name, right=child))
         else:
             tree_edges.append(
-                Edge(left=parent_name, right=child, label=original.label, poe=original.poe)
+                Edge(
+                    left=parent_name,
+                    right=child,
+                    label=original.label,
+                    poe=original.poe,
+                    wireless=original.wireless,
+                    speed=original.speed,
+                    channel=original.channel,
+                )
             )
     return tree_edges
 
@@ -492,6 +503,16 @@ def _client_is_wired(client: object) -> bool:
     return bool(_client_field(client, "is_wired"))
 
 
+def _client_channel(client: object) -> int | None:
+    for key in ("channel", "radio_channel", "wifi_channel"):
+        value = _client_field(client, key)
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str) and value.isdigit():
+            return int(value)
+    return None
+
+
 def _client_matches_mode(client: object, mode: str) -> bool:
     wired = _client_is_wired(client)
     if mode == "all":
@@ -528,12 +549,15 @@ def build_client_edges(
         key = (device_name, name)
         if key in seen:
             continue
+        is_wireless = not _client_is_wired(client)
+        channel = _client_channel(client) if is_wireless else None
         edges.append(
             Edge(
                 left=device_name,
                 right=name,
                 label=label,
-                wireless=not _client_is_wired(client),
+                wireless=is_wireless,
+                channel=channel,
             )
         )
         seen.add(key)
@@ -572,12 +596,14 @@ def build_edges(
     seen: set[frozenset[str]] = set()
     port_map: PortMap = {}
     poe_map: PoeMap = {}
+    speed_map: SpeedMap = {}
 
     devices_with_lldp_edges = _collect_lldp_links(
         ordered_devices,
         index,
         port_map,
         poe_map,
+        speed_map,
         raw_links,
         seen,
         only_unifi=only_unifi,
@@ -597,6 +623,7 @@ def build_edges(
         raw_links,
         port_map,
         poe_map,
+        speed_map,
         device_by_name,
         include_ports=include_ports,
     )
@@ -614,12 +641,14 @@ def build_port_map(devices: Iterable[Device], *, only_unifi: bool = True) -> Por
     seen: set[frozenset[str]] = set()
     port_map: PortMap = {}
     poe_map: PoeMap = {}
+    speed_map: SpeedMap = {}
 
     devices_with_lldp_edges = _collect_lldp_links(
         ordered_devices,
         index,
         port_map,
         poe_map,
+        speed_map,
         raw_links,
         seen,
         only_unifi=only_unifi,
@@ -661,11 +690,19 @@ def build_client_port_map(
     return port_map
 
 
+def _port_speed_by_idx(port_table: list[PortInfo], port_idx: int) -> int | None:
+    for port in port_table:
+        if port.port_idx == port_idx:
+            return port.speed
+    return None
+
+
 def _collect_lldp_links(
     devices: list[Device],
     index: dict[str, str],
     port_map: PortMap,
     poe_map: PoeMap,
+    speed_map: SpeedMap,
     raw_links: list[tuple[str, str]],
     seen: set[frozenset[str]],
     *,
@@ -704,8 +741,12 @@ def _collect_lldp_links(
             label = local_port_label(entry_for_label)
             if label:
                 port_map[(device.name, peer_name)] = label
-            if resolved_port_idx is not None and resolved_port_idx in poe_ports:
-                poe_map[(device.name, peer_name)] = poe_ports[resolved_port_idx]
+            if resolved_port_idx is not None:
+                if resolved_port_idx in poe_ports:
+                    poe_map[(device.name, peer_name)] = poe_ports[resolved_port_idx]
+                port_speed = _port_speed_by_idx(device.port_table, resolved_port_idx)
+                if port_speed is not None:
+                    speed_map[(device.name, peer_name)] = port_speed
 
             key = frozenset({device.name, peer_name})
             if key in seen:
@@ -794,6 +835,7 @@ def _build_ordered_edges(
     raw_links: list[tuple[str, str]],
     port_map: PortMap,
     poe_map: PoeMap,
+    speed_map: SpeedMap,
     device_by_name: dict[str, Device],
     *,
     include_ports: bool,
@@ -820,8 +862,9 @@ def _build_ordered_edges(
         poe = poe_map.get((left_name, right_name), False) or poe_map.get(
             (right_name, left_name), False
         )
+        speed = speed_map.get((left_name, right_name)) or speed_map.get((right_name, left_name))
         label = compose_port_label(left_name, right_name, port_map) if include_ports else None
-        edges.append(Edge(left=left_name, right=right_name, label=label, poe=poe))
+        edges.append(Edge(left=left_name, right=right_name, label=label, poe=poe, speed=speed))
     return edges
 
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -36,6 +36,13 @@ def test_build_client_edges_includes_wireless_when_requested():
     assert edges[0].wireless is True
 
 
+def test_build_client_edges_includes_channel_for_wireless():
+    device_index = {"aa:bb:cc:dd:ee:ff": "AP One"}
+    clients = [{"name": "Phone", "ap_mac": "aa:bb:cc:dd:ee:ff", "is_wired": False, "channel": 36}]
+    edges = build_client_edges(clients, device_index, client_mode="wireless")
+    assert edges[0].channel == 36
+
+
 def test_build_client_edges_includes_uplink_port_label():
     device_index = {"aa:bb:cc:dd:ee:ff": "Switch A"}
     clients = [

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -181,6 +181,22 @@ def test_build_edges_sets_poe_with_port_poe():
     assert edges[0].poe is True
 
 
+def test_build_edges_sets_speed_from_port():
+    dev_switch = DummyDevice(
+        "Switch A",
+        "aa:bb:cc:dd:ee:01",
+        [LLDPEntry("aa:bb:cc:dd:ee:02", "eth1", local_port_idx=1)],
+        port_table=[{"port_idx": 1, "speed": 1000}],
+    )
+    dev_ap = DummyDevice(
+        "AP One",
+        "aa:bb:cc:dd:ee:02",
+        [LLDPEntry("aa:bb:cc:dd:ee:01", "eth0")],
+    )
+    edges = build_edges(normalize_devices([dev_switch, dev_ap]))
+    assert edges[0].speed == 1000
+
+
 def test_coerce_device_uses_lldp_fallback():
     class DeviceWithLldp:
         name = "Device"


### PR DESCRIPTION
## Summary

Extends the Edge model with two new optional fields to support displaying link quality information:

- **`speed: int | None`** - Link speed in Mbps, extracted from `port_table` for wired device-to-device connections
- **`channel: int | None`** - Wireless channel, extracted from client data for wireless client connections

## Motivation

These fields enable downstream consumers (like Home Assistant integrations) to display more detailed connection information in network topology visualizations:

- Show link speed (e.g., 1000 Mbps, 2500 Mbps) for switch-to-switch or switch-to-AP connections
- Show wireless channel (e.g., channel 36, 149) to indicate which band clients are connected to

## Changes

### `src/unifi_network_maps/model/topology.py`
- Added `speed` and `channel` fields to `Edge` dataclass
- Added `SpeedMap` type alias
- Added `_port_speed_by_idx()` helper to look up port speed
- Added `_client_channel()` helper to extract channel from client data
- Updated `_collect_lldp_links()` to track speed from port table
- Updated `_build_ordered_edges()` to include speed in edges
- Updated `_tree_edges_from_parent()` to preserve speed/channel when creating tree edges
- Updated `build_client_edges()` to include channel for wireless clients

### Tests
- Added `test_build_edges_sets_speed_from_port()` in `test_topology.py`
- Added `test_build_client_edges_includes_channel_for_wireless()` in `test_clients.py`

## Test plan
- [x] All existing tests pass
- [x] New tests verify speed and channel are correctly populated
- [x] Type checking passes
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)