### PR TITLE
Add data-edge-left/right attributes to SVG paths

### DIFF
--- a/src/unifi_network_maps/render/svg.py
+++ b/src/unifi_network_maps/render/svg.py
@@ -547,8 +547,11 @@ def _render_svg_edges(
                 f"L {dst_cx} {mid_y} L {dst_cx} {dst_top}"
             )
         dash = ' stroke-dasharray="6 4"' if edge.wireless else ""
+        left_attr = _escape_attr(edge.left, quote=True)
+        right_attr = _escape_attr(edge.right, quote=True)
         lines.append(
-            f'<path d="{path}" stroke="{color}" stroke-width="{width_px}" fill="none"{dash}/>'
+            f'<path d="{path}" stroke="{color}" stroke-width="{width_px}" fill="none"{dash} '
+            f'data-edge-left="{left_attr}" data-edge-right="{right_attr}"/>'
         )
         if edge.poe:
             icon_x = dst_cx
@@ -834,9 +837,12 @@ def _render_iso_edges(
             dst_cy,
         )
         dash = ' stroke-dasharray="8 6"' if edge.wireless else ""
+        left_attr = _escape_attr(edge.left, quote=True)
+        right_attr = _escape_attr(edge.right, quote=True)
         lines.append(
             f'<path d="{" ".join(path_cmds)}" stroke="{color}" stroke-width="{width_px}" '
-            f'fill="none" stroke-linecap="round" stroke-linejoin="round"{dash}/>'
+            f'fill="none" stroke-linecap="round" stroke-linejoin="round"{dash} '
+            f'data-edge-left="{left_attr}" data-edge-right="{right_attr}"/>'
         )
         if edge.poe:
             icon_x = dst_cx

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -263,3 +263,30 @@ def test_render_svg_isometric_nodes_reference_iso_node_prefix():
         [Edge("A", "B")], node_types={"A": "switch", "B": "switch"}
     )
     assert 'fill="url(#iso-node-switch)"' in output
+
+
+def test_render_svg_adds_edge_data_attributes():
+    output = svg_module.render_svg(
+        [Edge("Gateway", "Switch")],
+        node_types={"Gateway": "gateway", "Switch": "switch"},
+    )
+    assert 'data-edge-left="Gateway"' in output
+    assert 'data-edge-right="Switch"' in output
+
+
+def test_render_svg_escapes_edge_data_attributes():
+    output = svg_module.render_svg(
+        [Edge('Node "A"', "Node <B>")],
+        node_types={'Node "A"': "gateway", "Node <B>": "switch"},
+    )
+    assert 'data-edge-left="Node &quot;A&quot;"' in output
+    assert 'data-edge-right="Node &lt;B&gt;"' in output
+
+
+def test_render_svg_isometric_adds_edge_data_attributes():
+    output = svg_module.render_svg_isometric(
+        [Edge("Gateway", "Switch")],
+        node_types={"Gateway": "gateway", "Switch": "switch"},
+    )
+    assert 'data-edge-left="Gateway"' in output
+    assert 'data-edge-right="Switch"' in output


### PR DESCRIPTION
## Summary
- Add `data-edge-left` and `data-edge-right` attributes to edge path elements in both regular and isometric SVG output
- Properly escape attribute values using `_escape_attr` for safe HTML output
- Add tests for the new attributes including escaping edge cases

## Motivation
Downstream consumers (like the Home Assistant integration) need to match SVG paths to their corresponding edges in the payload for edge hover/click interactions. Without identifying attributes, path order in the SVG doesn't match edge order in the payload because edges are sorted by PoE before rendering.

## Test plan
- [x] All existing tests pass
- [x] New tests verify data attributes are present in both regular and isometric SVG
- [x] New test verifies special characters are properly escaped

🤖 Generated with [Claude Code](https://claude.com/claude-code)