### PR TITLE
Improve model name detection by checking multiple UniFi API fields

### DIFF
--- a/src/unifi_network_maps/model/topology.py
+++ b/src/unifi_network_maps/model/topology.py
@@ -302,9 +302,29 @@ def _uplink_info(device: DeviceSource) -> tuple[UplinkInfo | None, UplinkInfo | 
     return uplink, last_uplink
 
 
+def _get_model_display_name(device: DeviceSource) -> str | None:
+    """Extract the human-readable model name from device data.
+
+    UniFi stores the friendly model name (e.g., 'USW Flex 2.5G 8 PoE') in various
+    fields depending on controller version. This function checks multiple candidates
+    and returns the first non-empty value found.
+    """
+    candidates = (
+        "model_in_lts",
+        "model_in_eol",
+        "shortname",
+        "model_name",
+    )
+    for key in candidates:
+        value = _get_attr(device, key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
 def coerce_device(device: DeviceSource) -> Device:
     name = _get_attr(device, "name")
-    model_name = _get_attr(device, "model_name") or _get_attr(device, "model")
+    model_name = _get_model_display_name(device) or _get_attr(device, "model")
     model = _get_attr(device, "model")
     mac = _get_attr(device, "mac")
     ip = _get_attr(device, "ip") or _get_attr(device, "ip_address")

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -20,6 +20,7 @@ from unifi_network_maps.model.topology import (
     _client_unifi_flag,
     _client_uplink_mac,
     _client_uplink_port,
+    _get_model_display_name,
     _parse_uplink,
     _poe_ports_from_device,
     _port_speed_by_idx,
@@ -735,3 +736,48 @@ def test_port_speed_by_idx_reads_speed():
 def test_classify_device_type_from_name():
     device = SimpleNamespace(type="", name="Gateway Main")
     assert classify_device_type(device) == "gateway"
+
+
+def test_get_model_display_name_prefers_model_in_lts():
+    device = SimpleNamespace(
+        model_in_lts="USW Flex 2.5G 8 PoE",
+        model_name="USW-Flex-2.5G-8-PoE",
+        model="USWFLEXPOE8",
+    )
+    assert _get_model_display_name(device) == "USW Flex 2.5G 8 PoE"
+
+
+def test_get_model_display_name_uses_model_in_eol():
+    device = SimpleNamespace(model_in_eol="USW Pro 24", model="USWPRO24")
+    assert _get_model_display_name(device) == "USW Pro 24"
+
+
+def test_get_model_display_name_uses_shortname():
+    device = SimpleNamespace(shortname="USW Mini", model="USWMINI")
+    assert _get_model_display_name(device) == "USW Mini"
+
+
+def test_get_model_display_name_falls_back_to_model_name():
+    device = SimpleNamespace(model_name="Dream Machine", model="UDM")
+    assert _get_model_display_name(device) == "Dream Machine"
+
+
+def test_get_model_display_name_returns_none_without_candidates():
+    device = SimpleNamespace(model="USWFLEX")
+    assert _get_model_display_name(device) is None
+
+
+def test_coerce_device_uses_model_in_lts_for_model_name():
+    device = SimpleNamespace(
+        name="Switch",
+        mac="aa:bb:cc:dd:ee:ff",
+        model_in_lts="USW Flex 2.5G 8 PoE",
+        model="USWFLEXPOE8",
+        ip="",
+        type="usw",
+        lldp_info=[],
+        port_table=[],
+    )
+    result = coerce_device(device)
+    assert result.model_name == "USW Flex 2.5G 8 PoE"
+    assert result.model == "USWFLEXPOE8"


### PR DESCRIPTION
## Summary
- Add `_get_model_display_name()` helper to check multiple fields for human-readable model names
- Check `model_in_lts`, `model_in_eol`, `shortname`, and `model_name` in order of preference
- Fixes devices showing internal model codes (e.g., 'USWFLEXPOE8') instead of friendly names (e.g., 'USW Flex 2.5G 8 PoE')

## Test plan
- [x] Added unit tests for `_get_model_display_name()` covering all field candidates
- [x] Added integration test for `coerce_device()` using `model_in_lts`
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)