### PR TITLE
Classify UXG-type devices as gateways

### DIFF
--- a/src/unifi_network_maps/model/classify.py
+++ b/src/unifi_network_maps/model/classify.py
@@ -57,7 +57,7 @@ def classify_device_type(device: object) -> str:
         raw_name = get_field(device, "name")
         name = raw_name if isinstance(raw_name, str) else ""
         return _classify_by_device_name(name) or "other"
-    if value in {"gateway", "ugw", "usg", "udm", "udr"}:
+    if value in {"gateway", "ugw", "usg", "udm", "udr", "uxg"}:
         return "gateway"
     if value == "ux":
         in_gw_mode = get_field(device, "in_gateway_mode")

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -48,6 +48,20 @@ def test_classify_ux_gateway_mode_explicit_true():
     assert classify_device_type(device) == "gateway"
 
 
+def test_classify_uxg_type_as_gateway():
+    """UXG-series devices (UXG-Pro, UXG-Max/UXGB) report type 'uxg'."""
+    device = Device(
+        name="UXG Max",
+        model_name="",
+        model="UXGB",
+        mac="dd",
+        ip="",
+        type="uxg",
+        lldp_info=[],
+    )
+    assert classify_device_type(device) == "gateway"
+
+
 def test_group_devices_by_type_includes_ap():
     devices = [
         Device(name="AP One", model_name="", model="", mac="aa", ip="", type="uap", lldp_info=[])


### PR DESCRIPTION
## Summary

- UXG-series devices (UXG-Pro, UXG-Max/UXGB) report `type="uxg"` from the UniFi controller, which was not recognized as a gateway type and fell through to `"other"`
- Add `"uxg"` to the gateway type set in `classify_device_type()`
- Add test case for UXG-type device classification

## Context

The existing `type="ux"` handling (with `in_gateway_mode` check) covers UX7-style devices, but standalone UXG gateways like the UXG-Max report a distinct `type="uxg"` that needs direct recognition.

Fixes merlijntishauser/unifi-network-maps-ha#50

## Test plan

- [x] New test `test_classify_uxg_type_as_gateway` passes
- [x] All existing classification tests pass (809 passed)